### PR TITLE
fix: enable dependabot grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,17 @@ updates:
       interval: "weekly"
       day: sunday
     open-pull-requests-limit: 20
+    groups:
+      go-everything:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
     open-pull-requests-limit: 20
+    groups:
+      actions-everything:
+        patterns:
+          - "*"


### PR DESCRIPTION
https://github.blog/changelog/2023-08-24-grouped-version-updates-for-dependabot-are-generally-available/

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups